### PR TITLE
updated imports to remove deprecation warnings

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, redirect, url_for, render_template
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from flask.ext.login import LoginManager, UserMixin, login_user, logout_user,\
     current_user
 from oauth import OAuthSignIn

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, redirect, url_for, render_template
 from flask_sqlalchemy import SQLAlchemy
-from flask.ext.login import LoginManager, UserMixin, login_user, logout_user,\
+from flask_login import LoginManager, UserMixin, login_user, logout_user,\
     current_user
 from oauth import OAuthSignIn
 


### PR DESCRIPTION
Warnings when running the app:

Python27\lib\site-packages\flask\exthook.py:71: ExtDeprecationWarning: Importing flask.ext.sqlalchemy is deprecated, use flask_sqlalchemy instead.
  .format(x=modname), ExtDeprecationWarning

Python27\lib\site-packages\flask\exthook.py:71: ExtDeprecationWarning: Importing flask.ext.login is deprecated, use flask_login instead.
  .format(x=modname), ExtDeprecationWarning
