### PR TITLE
Patch facebook Oauth to work with both Python 2.7 and Python 3.6

### DIFF
--- a/oauth.py
+++ b/oauth.py
@@ -1,6 +1,6 @@
 from rauth import OAuth1Service, OAuth2Service
 from flask import current_app, url_for, request, redirect, session
-
+from simplejson import json 
 
 class OAuthSignIn(object):
     providers = None
@@ -56,7 +56,8 @@ class FacebookSignIn(OAuthSignIn):
         oauth_session = self.service.get_auth_session(
             data={'code': request.args['code'],
                   'grant_type': 'authorization_code',
-                  'redirect_uri': self.get_callback_url()}
+                  'redirect_uri': self.get_callback_url()},
+            decoder = json.loads
         )
         me = oauth_session.get('me?fields=id,email').json()
         return (

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ argparse==1.2.1
 itsdangerous==0.24
 rauth==0.7.0
 requests==2.4.3
+simplejson==3.10.0


### PR DESCRIPTION
I follow your guide thoroughly but can't make it work. I have tried both Python 2.7 and Python 3.6. 
At first, it seems that facebook now requires a decoder. Try running the code in both python version results in  `KeyError: 'Decoder failed to handle access_token with data as returned by provider. A different decoder may be needed.`  
So I make a simple fix for python 2.7 by importing json module and pass in a decoder, which literally means :

```python
import json 
[...]
        data = ...,
        decoder = json.loads
[...]
```  
And now everything works fine. I am able to logged in via facebook. But when this method is applied with python3, it results in  another error `the JSON object must be str, not 'bytes'`, which leads me to another fix:

```python
import  simplejson as json 
[...]
        data = ...,
        decoder = json.loads
[...]
```  

Although I dont know the difference between the default json module in python3 and in the package simplejson, the codes now work great with both version of python. 

